### PR TITLE
Updated to latest aws sdk version 1.10.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,13 @@
 
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.3.26</version>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>1.10.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.10.4</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Now that aws sdk is modularized (1.9.0 onwards), also reduced
dependency to just core/s3 modules.

The update is needed to take advantage of the newer aws auth mechanisms like ProfileCredentialsProvider.