### PR TITLE
Added support for passing proxy parameters for S3 connection.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,10 @@ Configuration parameters
 |secretKey|S3 secret key | *no* | if unspecified, uses the Default Provider, falling back to env variables |
 |doNotUpload|Dry run| *no* | false |
 |endpoint|Use a different s3 endpoint| *no* | s3.amazonaws.com |
+|proxyHost|Proxy host for S3 connection| *no* | |
+|proxyPort|Proxy host for S3 connection| *no* | |
+|proxyUsername|Proxy username | *no* | |
+|proxyPassword|Proxy password | *no* | |
 
 Example: Upload a file
 ----------------------

--- a/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
@@ -1,9 +1,7 @@
 package com.bazaarvoice.maven.plugins.s3.upload;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.*;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -59,6 +57,22 @@ public class S3UploadMojo extends AbstractMojo
   @Parameter(property = "s3-upload.recursive", defaultValue = "false")
   private boolean recursive;
 
+  /** Proxy host **/
+  @Parameter(property = "s3-upload.proxyHost")
+  private String proxyHost;
+
+  /** Proxy port **/
+  @Parameter(property = "s3-upload.proxyPort")
+  private int proxyPort;
+
+  /** Proxy username **/
+  @Parameter(property = "s3-upload.proxyUsername")
+  private String proxyUsername;
+
+  /** Proxy password **/
+  @Parameter(property = "s3-upload.proxyPassword")
+  private String proxyPassword;
+
   @Override
   public void execute() throws MojoExecutionException
   {
@@ -91,7 +105,7 @@ public class S3UploadMojo extends AbstractMojo
             source, bucketName, destination));
   }
 
-  private static AmazonS3 getS3Client(String accessKey, String secretKey)
+  private AmazonS3 getS3Client(String accessKey, String secretKey)
   {
     AWSCredentialsProvider provider;
     if (accessKey != null && secretKey != null) {
@@ -100,7 +114,16 @@ public class S3UploadMojo extends AbstractMojo
     } else {
       provider = new DefaultAWSCredentialsProviderChain();
     }
-
+    ClientConfiguration clientConfiguration;
+    if (proxyHost != null)
+    {
+      clientConfiguration = new ClientConfiguration()
+              .withProxyHost(proxyHost)
+              .withProxyPort(proxyPort)
+              .withProxyUsername(proxyUsername)
+              .withProxyPassword(proxyPassword);
+      return new AmazonS3Client(provider, clientConfiguration);
+    }
     return new AmazonS3Client(provider);
   }
 


### PR DESCRIPTION
The commit addresses the issue below:
https://github.com/bazaarvoice/s3-upload-maven-plugin/issues/22

This is also needed for my project. It bases on prehistoric AWS api version the plugin already depends on (1.10.69).
Could you please merge it to the master and release new version of plugin?