### PR TITLE
Add property to skip execution

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
@@ -59,9 +59,17 @@ public class S3UploadMojo extends AbstractMojo
   @Parameter(property = "s3-upload.recursive", defaultValue = "false")
   private boolean recursive;
 
+  /** Skip execution. */
+  @Parameter(property = "s3-upload.skip", defaultValue = "false")
+  private boolean skip;
+
   @Override
   public void execute() throws MojoExecutionException
   {
+    if (skip) {
+      getLog().info("Skipping S3 upload");
+      return;
+    }
     if (!source.exists()) {
       throw new MojoExecutionException("File/folder doesn't exist: " + source);
     }


### PR DESCRIPTION
This adds a property `skip` with a user property `s3-upload.skip` that skips execution of the plugin. This is similar to the `skip` property of the `maven-deploy-plugin`.

This allows the plugin to be configured in the parent module of a multi-module project and skipped in the parent and any of the sub-modules that don't need to upload.