### PR TITLE
update aws-sdk to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,18 +102,18 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.10.69</version>
+      <version>1.11.820</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.10.69</version>
+      <version>1.11.820</version>
     </dependency>
     <dependency>
       <!-- The STS SDK is necessary if role based profiles are used for credentials. -->
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.10.69</version>
+      <version>1.11.820</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
When plugin is used in docker container on EC2 instance it assumes instance role instead of docker container's one.
Update to aws-sdk latest version fixes this issue.