### PR TITLE
Default credentials provider

### DIFF
--- a/src/main/java/com/bazaarvoice/maven/plugins/s3/wrapper/SSOCompatibleCredentialsProvider.java
+++ b/src/main/java/com/bazaarvoice/maven/plugins/s3/wrapper/SSOCompatibleCredentialsProvider.java
@@ -5,14 +5,16 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 
 public class SSOCompatibleCredentialsProvider implements AWSCredentialsProvider {
-    private final ProfileCredentialsProvider delegate;
+    private final AwsCredentialsProvider delegate;
 
     public SSOCompatibleCredentialsProvider() {
-        this.delegate = ProfileCredentialsProvider.create();
+        this.delegate = DefaultCredentialsProvider.create();
     }
 
     public SSOCompatibleCredentialsProvider(String profileName) {


### PR DESCRIPTION
Use `DefaultCredentialsProvider` by default. Allows to run plugin in the ec2/ecs and other environments where credentials provided via other mechanisms like ec2 instance profile.