### PR TITLE
Fix: plugin needs to support temp creds 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Configuration parameters
 |profileName|AWS profile | *no* | if unspecified, uses the ProfileCredentialsProvider Provider, falling back to env variables |
 |accessKey|S3 access key | *no* | if unspecified, uses the ProfileCredentialsProvider Provider, falling back to env variables |
 |secretKey|S3 secret key | *no* | if unspecified, uses the ProfileCredentialsProvider Provider, falling back to env variables |
+|sessionToken|Session token for AWS security token service (STS) credentials. Used with accessKey and secretKey | *no* | if unspecified, uses the ProfileCredentialsProvider Provider, falling back to env variables |
 |doNotUpload|Dry run| *no* | false |
 |endpoint|Use a different s3 endpoint| *no* | s3.amazonaws.com |
 

--- a/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
@@ -1,6 +1,9 @@
 package com.bazaarvoice.maven.plugins.s3.upload;
 
-import com.amazonaws.auth.*;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;

--- a/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
+++ b/src/main/java/com/bazaarvoice/maven/plugins/s3/upload/S3UploadMojo.java
@@ -1,9 +1,6 @@
 package com.bazaarvoice.maven.plugins.s3.upload;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.*;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -36,6 +33,10 @@ public class S3UploadMojo extends AbstractMojo
   /** Secret key for S3. */
   @Parameter(property = "s3-upload.secretKey")
   private String secretKey;
+
+  /** Session token for s3. This is used for temporary credentials. */
+  @Parameter(property = "s3-upload.sessionToken")
+  private String sessionToken;
 
   /**
    *  Execute all steps up except the upload to the S3.
@@ -75,7 +76,7 @@ public class S3UploadMojo extends AbstractMojo
     if (profileName != null) {
       s3 = getS3Client(profileName);
     } else {
-      s3 = getS3Client(accessKey, secretKey);
+      s3 = getS3Client(accessKey, secretKey, sessionToken);
     }
 
     if (endpoint != null) {
@@ -102,12 +103,19 @@ public class S3UploadMojo extends AbstractMojo
             source, bucketName, destination));
   }
 
-  private static AmazonS3 getS3Client(String accessKey, String secretKey)
+  private static AmazonS3 getS3Client(String accessKey, String secretKey, String sessionToken)
   {
     AWSCredentialsProvider provider;
     if (accessKey != null && secretKey != null) {
-      AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
-      provider = new StaticCredentialsProvider(credentials);
+      if (sessionToken != null) {
+        // Use the provided session token
+        AWSCredentials credentials = new BasicSessionCredentials(accessKey, secretKey, sessionToken);
+        provider = new StaticCredentialsProvider(credentials);
+      } else {
+        // Use basic credentials without a session token
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        provider = new StaticCredentialsProvider(credentials);
+      }
     } else {
       provider = new SSOCompatibleCredentialsProvider();
     }


### PR DESCRIPTION
This change is required if we wish to use aws-actions/configure-aws-credentials@v4 for generating temp creds for AWS access. Currently the plugin only supports Profiles or ID and Key. This change adds support for session token.